### PR TITLE
Signature Proposal

### DIFF
--- a/shop_events.proto
+++ b/shop_events.proto
@@ -199,9 +199,6 @@ message UpdateOrder {
 // Therefore, the structured data specification
 // needs to be pruned from fields that are not set.
 message ShopEvent {
-  // use ecrecover() to extract the keycard that created the event
-  bytes signature = 1;
-
   oneof union {
     ShopManifest shop_manifest = 2;
     UpdateShopManifest update_shop_manifest = 3;

--- a/transport.proto
+++ b/transport.proto
@@ -42,10 +42,15 @@ import "error.proto";
 // Event syncronization
 // ====================
 
+message SignedEvent {
+  google.protobuf.Any event = 1;
+  bytes signature = 2; // EIP-191 of any.value
+}
+
 // Used by the Client to write a single event to the shop.
 message EventWriteRequest {
   bytes request_id = 1;
-  google.protobuf.Any event = 2;
+  SignedEvent event = 2;
 }
 
 // Might return an error if the event or its signature is invalid.
@@ -63,7 +68,7 @@ message EventWriteResponse {
 // Will not sent more events until the client has acknowledged the last batch.
 message EventPushRequest {
   bytes request_id = 1;
-  repeated google.protobuf.Any events = 2;
+  repeated SignedEvent events = 2;
 }
 
 message EventPushResponse {


### PR DESCRIPTION
This is a Proposal to rework our signature scheme on events. 

## History

We started with using [eip-712 ](https://eips.ethereum.org/EIPS/eip-712) for signing. This is in part for merchants to add create invites they need to sign with there onchain wallets. Wallet software utilizes eip-721 to display information on what is being signed, instead of just a blob of data. 

###  Problem

1) Currently we need to serialize the data twice in two different formats, once for the eip-712 signature and then again with protobuff
2) There is impedance mismatch between protobufs and eip-712, optional, unions and several base data types have no direct mapping between the formats
3) implementation complexity; a good amount of code is dedicated to converting between the format at least in the ts-client. This code is not well tested and is brittle. Every time we change the protobuf schema we have to match that in eip-712.

### Proposal

An alternative is that we use [eip-191](https://eips.ethereum.org/EIPS/eip-191) for all signatures that are not going to be used on chain. (invites should still uses eip-721). 
EIP-191 is very simple 
```
hash = keccak256("\x19Ethereum Signed Message:\n" + len(message) + message))
signature = sign(hash)
```
Where the `message` is a serialized shop event .
Since these signature are not meant to be manually reviewed by users, it is fine to just sign over a blob of data here. 

One down side is that it makes the protobufs definition's less explicit. The idea of using a data field to store a serialized protobuf came from [Protobuf encoded Policy in chrome](https://chromium.googlesource.com/chromium/src/components/policy/proto/+/HEAD/device_management_backend.proto#151) Ref: https://www.chromium.org/developers/how-tos/enterprise/protobuf-encoded-policy-blobs/
