### PR TITLE
proposal to use seperate RPC for guest checkouts

### DIFF
--- a/shop_events.proto
+++ b/shop_events.proto
@@ -53,10 +53,6 @@ message Account {
   // Binds the keycard to a wallet address of the user
   message KeyCardEnroll {
     PublicKey keycard_pubkey = 1;
-    // TODO: move to docs
-    // What to do about checkouts of guest keycards?
-    // - set to zero address
-    // - expose  secret key during checkout for recovering access to order
     EthereumAddress user_wallet = 2;
   }
 }
@@ -154,6 +150,8 @@ message Order {
 
   // set once payment was witnessed
   optional OrderPaid paid = 10;
+
+  optional Signature guest_signature = 11;
 }
 
 message CreateOrder {
@@ -165,14 +163,24 @@ message UpdateOrder {
 
   oneof action {
     Canceled canceled = 2;
+
     ChangeItems change_items = 3;
-    AddressDetails invoice_address = 4;
+
+    // fixes the items to the order and starts payment timeout
+    CommitItems commit = 4;
+
+    AddressDetails invoice_address = 5;
     // no shipping addr assumes invoice addr
-    AddressDetails shipping_address = 5;
-    // invoice address needs to be filled in before it can be commited
-    CommitItems commit = 6;
-    PaymentDetails payment_details = 7;
-    OrderPaid paid = 8;
+    AddressDetails shipping_address = 6;
+
+    ChoosePayment choose_payment = 7;
+    PaymentDetails payment_details = 8;
+
+    OrderPaid paid = 9;
+  }
+
+  message CommitItems {
+    // emtpy
   }
 
   // only valid before items were commited to the order
@@ -183,7 +191,7 @@ message UpdateOrder {
 
   // Created by a customer when they are ready to purchase an order
   // This is followed by a PaymentDetails message
-  message CommitItems {
+  message ChoosePayment {
     // has to be an accepted currency on the manifest
     ShopCurrency currency = 1;
     Payee payee = 2;

--- a/shop_requests.proto
+++ b/shop_requests.proto
@@ -6,7 +6,9 @@ syntax = "proto3";
 
 package market.mass;
 
-import "error.proto";
+import "base_types.proto";
+import "google/protobuf/any.proto";
+import "shop_events.proto";
 
 // Get an URL to upload a blob to.
 // This exists for future-proofing the protocol
@@ -15,11 +17,40 @@ message GetBlobUploadURLRequest {
   // empty
 }
 
-// Returns a single-use URL to upload a blob to.
-// The HTTP response will contain the blob's IPFS path.
-message GetBlobUploadURLResponse {
-  oneof result {
-    Error error = 2;
-    string url = 3;
+// Returns a nonce as response payload to sign over with their guest id
+message GuestStartOrderRequest {
+  uint64 order_id = 1;
+}
+
+// Used by an external user (ie not a keycard holder) to facilitate a purchase.
+// this locks the items of this order.
+// TODO: could expose secret key during checkout for recovering access to order
+message GuestStartCheckoutRequest {
+  // TODO: any to make signature verification a tad simpler. just a crutch
+  google.protobuf.Any signed_order = 1;
+  Signature guest_signature = 2;
+
+  message SignedOrder {
+    // order.id needs to be order_id from GuestStartCheckout
+    // state needs to be commited.
+    // unset: paid, payment_details and canceled_at.
+    Order order = 1;
+    bytes nonce = 2;
+  }
+}
+
+message GuestChoosePaymentRequest {
+  // See TODO above
+  google.protobuf.Any complete_checkout = 1;
+  Signature guest_signature = 2;
+
+  message CompleteCheckout {
+    AddressDetails invoice_address = 1;
+    // no shipping addr assumes invoice_address for shipping
+    AddressDetails shipping_address = 2;
+    ShopCurrency currency = 3;
+    Payee payee = 4;
+
+    bytes nonce = 5;
   }
 }

--- a/subscription.proto
+++ b/subscription.proto
@@ -13,20 +13,32 @@ import "transport.proto";
 enum ObjectType {
   OBJECT_TYPE_UNSPECIFIED = 0; // invalid
 
-  OBJECT_TYPE_LISTING = 1;
-  OBJECT_TYPE_TAG = 2;
-  OBJECT_TYPE_ORDER = 3;
-  // accounts refer to keycards enrollments and customer accounts
-  OBJECT_TYPE_ACCOUNT = 4;
-  OBJECT_TYPE_MANIFEST = 5;
+  // public
+  // ======
+
+  OBJECT_TYPE_MANIFEST = 1;
+  OBJECT_TYPE_LISTING = 2;
+  OBJECT_TYPE_TAG = 3;
+
+  // private
+  // =======
+
+  // accessible to clerks
+  // and users who can proof that their theirs
+  OBJECT_TYPE_ORDER = 4;
+
+  // clerks only
+  // ===========
+
+  // accounts refer to keycards enrollments and employee accounts
+  OBJECT_TYPE_ACCOUNT = 5;
   // inventory is seperated since you must first authenticate to get the events
   OBJECT_TYPE_INVENTORY = 6;
 }
 
 // Used by the client to subscribe to a subset of event from the store
 //
-// reponse via GenericResponse
-// which notifies the client wether the subscription was succseful
+// reponds with a subscription_id in the GenericResponse payload if successful.
 message SubscriptionRequest {
   // The relay will send events from the shop log starting from this
   // sequence number.
@@ -40,7 +52,7 @@ message SubscriptionRequest {
   repeated Filter filters = 3;
   message Filter {
     // Which object that is being subscribed to. Subscribing to an object
-    // will return a  stream of events
+    // will return a stream of events
     // that modify that object type. For example subscribing to LISTING
     // will return a stream of all the events
     // that modify listings in the store.
@@ -48,7 +60,7 @@ message SubscriptionRequest {
     // Optional subscribe to only events that modify a single item.
     // We assume object_id is only unique for a given object_type, so
     // object_type is required.
-    optional bytes object_id = 4;
+    optional uint64 object_id = 4;
   }
 }
 
@@ -58,5 +70,19 @@ message SubscriptionRequest {
 // Client sends a GenericResponse without an error to acknowledge recepetion.
 // To close a subscription, respond with ERROR_CODES_CLOSE_SUBSCRIPTION
 message SubscriptionPushRequest {
-  repeated SignedEvent events = 1;
+  bytes subscription_id = 1;
+  repeated SignedEvent events = 2;
+}
+
+// Precursor to making a subscription for guest orders
+// On success responds with a subscription_id which needs to be signed over
+// with the same keypair that was used for the order
+message GuestOrdersAccessRequest {
+  Uint256 shop_id = 1;
+  repeated uint64 order_ids = 2;
+}
+
+message GuestOrdersSubscriptionRequest {
+  bytes subscription_id = 1;
+  Signature guest_signature = 2;
 }


### PR DESCRIPTION
motivation: remove the need for guests to use keyCards entirely

- we still want them to sign the orders and updates. This tries to put their key pairs in a different class/domain, separate from keyCards. 
- we can give them a magic link (using the secret) to keep accessing the _status_ of the order but they can't edit it after choosing payment.

tradeofs:
- less keycards! the relay will create events on their behalf
- they can't use EventWrite => seperate set of RPCs

To do so, this adds a handful of requests. guests would get access to their order status via the new subscription.


to create and commit orders:

* GuestStartOrderRequest
* GuestStartCheckoutRequest
* GuestChoosePaymentRequest

to get payment details and status updates

* GuestOrdersAccessRequest
* GuestOrdersSubscriptionRequest


aside:
- adds a subscription_id so that clients can differentiate push requests.
