### PR TITLE
Token Based Authentication For Patching and Subscriptions 

### DIFF
--- a/cddl/patch.cddl
+++ b/cddl/patch.cddl
@@ -2,12 +2,8 @@
 ;
 ; SPDX-License-Identifier: MIT
 
-SignedPatchSet = {
-  Header: PatchSetHeader,
-  Signature: Signature,
-  Patches: [+ Patch]
-}
 
+PublicKey = bytes
 Hash = bytes .size 32
 Signature = bytes .size 65
 Uint256 = bytes .size (1..32)
@@ -15,12 +11,25 @@ Uint256 = bytes .size (1..32)
 PathSegment = text / unsigned / bytes
 OpString = "add" / "replace" / "remove" / "increment" / "decrement" / "append"
 
-PatchSetHeader = {
-  KeyCardNonce: uint,
-  ShopID: Uint256,
-  Timestamp: text,
-  RootHash: Hash
+Capability = {
+  can: [+ OpString],
+  path: [+ PathSegment]
 }
+
+CapTokenHeader = {
+  iss: PublicKey      ; the PublicKey of the issuer
+  ? exp: uint,        ; Expiration Time https://datatracker.ietf.org/doc/html/rfc7519#section-4.1.4
+  ? nfb: uint,        ; not before https://datatracker.ietf.org/doc/html/rfc7519#section-4.1.5
+  aud: bytes,         ; audence https://datatracker.ietf.org/doc/html/rfc7519#section-4.1.3
+  shopid: bytes,
+  caps: [+ Capability]
+  proofs: [+ CapToken];
+}
+
+CapToken = [
+ CapHeader,
+ signature
+]
 
 Patch = {
   Op: OpString,
@@ -28,3 +37,14 @@ Patch = {
   Value: any
 }
 
+PatchSetHeader = {
+  token: CapToken,
+  patchSetRootHash: bytes
+  nonce: uint,
+  iat: uint         ; Issued At https://datatracker.ietf.org/doc/html/rfc7519#section-4.1.3
+}
+
+SignedPatchSet = [
+  header: PatchSetHeader,
+  signature : bstr
+]

--- a/cddl/patch.cddl
+++ b/cddl/patch.cddl
@@ -2,7 +2,6 @@
 ;
 ; SPDX-License-Identifier: MIT
 
-
 PublicKey = bytes
 Hash = bytes .size 32
 Signature = bytes .size 65
@@ -11,40 +10,90 @@ Uint256 = bytes .size (1..32)
 PathSegment = text / unsigned / bytes
 OpString = "add" / "replace" / "remove" / "increment" / "decrement" / "append"
 
-Capability = {
-  can: [+ OpString],
-  path: [+ PathSegment]
-}
-
-CapTokenHeader = {
-  iss: PublicKey      ; the PublicKey of the issuer
-  ? exp: uint,        ; Expiration Time https://datatracker.ietf.org/doc/html/rfc7519#section-4.1.4
-  ? nfb: uint,        ; not before https://datatracker.ietf.org/doc/html/rfc7519#section-4.1.5
-  aud: bytes,         ; audence https://datatracker.ietf.org/doc/html/rfc7519#section-4.1.3
-  shopid: bytes,
-  caps: [+ Capability]
-  proofs: [+ CapToken];
-}
-
-CapToken = [
- CapHeader,
- signature
-]
-
 Patch = {
   Op: OpString,
   Path: [+ PathSegment],
   Value: any
 }
 
-PatchSetHeader = {
-  token: CapToken,
+PatchSet = {
+  tokens: [+CapToken],
   patchSetRootHash: bytes
   nonce: uint,
   iat: uint         ; Issued At https://datatracker.ietf.org/doc/html/rfc7519#section-4.1.3
 }
 
-SignedPatchSet = [
-  header: PatchSetHeader,
-  signature : bstr
-]
+CoseHeader = {
+   alg: -47 /  -65537 ; sep256k1 or SIWE encoded
+}
+
+SignedPatchSet = #6.18([
+   header : bstr .cbor CoseHeader,
+   payload : bstr .cbor PatchSet,
+   Signature
+])
+
+Capability = {
+  can: [+ OpString],
+  path: [+ PathSegment]
+}
+
+CapTokenPayload = {
+  iss: PublicKey      ; the PublicKey of the issuer
+  aud: bytes,         ; audence https://datatracker.ietf.org/doc/html/rfc7519#section-4.1.3
+  iat: uint           ; Issued At https://datatracker.ietf.org/doc/html/rfc7519#section-4.1.3
+  ? exp: uint,        ; Expiration Time https://datatracker.ietf.org/doc/html/rfc7519#section-4.1.4
+  ? nfb: uint,        ; not before https://datatracker.ietf.org/doc/html/rfc7519#section-4.1.5
+  shopid: Uint256,
+  att: [+ Capability] ; attenuation https://github.com/ucan-wg/ucan-ipld/?tab=readme-ov-file
+  prf: [* CapToken];   ; proof
+}
+
+CapToken = #6.18([
+ header : bytes .cbor CoseHeader,
+ payload : bytes .cbor CapTokenPayload,
+ Signature
+])
+
+GuestCaps = [{
+  can: ["read"],
+  path: ["listings"]
+}, {
+  can: ["read"],
+  path: ["manifest"]
+}, {
+  can: ["read"],
+  path: ["tags"]
+}, {
+  can: ["add"],
+  path: ["orders"]
+}]
+
+ClerkCaps = [{
+  can: ["read", "write"],
+  path: ["listings"]
+}, {
+  can: ["read", "write"],
+  path: ["manifest"]
+}, {
+  can: ["read", "write"],
+  path: ["tags"]
+},{
+  can: ["read", "write"],
+  path: ["orders"]
+}]
+
+SubscriptionReqest = {
+ // The relay will send events from the shop log starting from this
+ // sequence number.
+ start_shop_seq_no: uint64,
+ // paths being subscribed to
+ paths = [+ [+ PathSegment]],
+ tokens = [+ CapToken]
+}
+
+SignedSubscriptionReqest = #6.18([
+   header : bstr .cbor CoseHeader,
+   payload : bstr .cbor SubscriptionReqest,
+   Signature
+])

--- a/cddl/shop_logical.cddl
+++ b/cddl/shop_logical.cddl
@@ -14,7 +14,7 @@ Shop = {
 
 ; HAMT-like map types
 
-Accounts = { * EthereumAddress => Account }
+AccountsClerk = [ * EthereumAddress ]
 Listings = { * uint => Listing }
 Tags = { * text => Tag }
 Orders = { * uint => Order }
@@ -120,12 +120,6 @@ ListingStockStatus = {
 Tag = {
     Name: text,
     ListingIDs: [* uint]
-}
-
-; Account
-Account = {
-    KeyCards: [* PublicKey],
-    Guest: bool
 }
 
 ; Order

--- a/subscription.proto
+++ b/subscription.proto
@@ -48,6 +48,8 @@ message SubscriptionRequest {
     // object_type is required.
     optional ObjectId object_id = 4;
   }
+  // the cbor encoded capability token
+  bytes token = 5;
 }
 
 // Used by the relay to push events to the client.

--- a/subscription.proto
+++ b/subscription.proto
@@ -26,30 +26,8 @@ enum ObjectType {
 //
 // on success responds with a subscription_id in the payload of GenericResponse
 message SubscriptionRequest {
-  // The relay will send events from the shop log starting from this
-  // sequence number.
-  // what happens if this no longer exists?
-  uint64 start_shop_seq_no = 1;
-  // The id of the shop that is being subscribed to. If an objectType
-  // is not specified then the relay will return all the events for
-  // the shop given the currently level of authentication.
-  Uint256 shop_id = 2;
-  // Filter can be applied to return only a subset of events
-  repeated Filter filters = 3;
-  message Filter {
-    // Which object that is being subscribed to. Subscribing to an object
-    // will return a  stream of events
-    // that modify that object type. For example subscribing to LISTING
-    // will return a stream of all the events
-    // that modify listings in the shop.
-    ObjectType object_type = 3;
-    // Optional subscribe to only events that modify a single item.
-    // We assume object_id is only unique for a given object_type, so
-    // object_type is required.
-    optional ObjectId object_id = 4;
-  }
-  // the cbor encoded capability token
-  bytes token = 5;
+  // the cbor encoded signedSubscriptionRequest
+  bytes cbor = 5;
 }
 
 // Used by the relay to push events to the client.


### PR DESCRIPTION
## Problems
- a subscription's authentication is tied authentication status of the websocket connection, meaning a new connection need to be made to change privileges. And subscription logic must reach into or have access to a global connection status. 
- customers aka "guest" create key-cards that litter the state
- customers may want to associate their "guest" keycard with a permanent account (ethereum) for long term access of their state
- no ability to define new roles with out protocol changes
- new clerks must be added onchain

## Proposed Solution
Use a token as a capability. This approach has been adopted from [UCAN](https://github.com/ucan-wg/spec) but uses [rfc8152](https://datatracker.ietf.org/doc/html/rfc8152) as the format. The basic idea is that instead of the relay storing a bunch of keycards in the form of public keys, the relay will issue a sign token that can be used as a capability for reading and writing to the store. This alleviates the relay from having to store key-cards altogether (except in the case of revoking). 

We can define a capability in ourcase as follows
```
Capability = {
  can: [+ OpString],
  path: [+ PathSegment]
}
```
For example 
```
{
   can: ["delete", "replace", "add"]
   path: [ "listings" ]
}
```
would give that holder the ability to "delete", "replace", "add" any listing. To simplify things we can have two verbs "read" "write" for the `can` field.  This capabilities would then be included in a payload as defined below. 
```
CapTokenPayload = {
  iss: PublicKey      ; the PublicKey of the issuer
  ? exp: uint,        ; Expiration Time https://datatracker.ietf.org/doc/html/rfc7519#section-4.1.4
  ? nfb: uint,        ; not before https://datatracker.ietf.org/doc/html/rfc7519#section-4.1.5
  aud: PublicKey,         ; audence https://datatracker.ietf.org/doc/html/rfc7519#section-4.1.3
  shopid: Uint256,
  caps: [+ Capability]
  att: [+ Capability];   ; attenuation
  prf: [* CapToken];   ; proof
}
```

- `iss` would be one of the shops relay or the merchant
- `exp` is the date at which the token expires
- `nfb` is the date after which the token can be used
- `aud` is the publickey the user of the token
- `shopid` is the shopid
- `att` a list of capabilities that are being issued to `aud`
- `prf` are a list of Token from which this token derives its authority if any, if there are none this is a root capability. 

A patch set is now augmented to also included the capability in it. 
```
PatchSet = {
  tokens: [+CapToken],
  patchSetRootHash: bytes
  nonce: uint,
  iat: uint                   ; Issued At https://datatracker.ietf.org/doc/html/rfc7519#section-4.1.3
}
```

The patchset MAY include more then one token. To validate the patchset the verifier 
1. validate the tokens
  a. check `nfb` and `exp` against the current date
  b. make sure `iss` is either a relay or the merchant 
  c. validate the signature 
3. needs to loop through the patches and check if the capabilities to apply the action exists in the tokens

## HTTP endpoint
The HTTP endpoint `request_token/guest` and `request_token/clerk` should replace `enroll_keycard`.  And should return a token with `GuestCap`  or `ClerkCap` as the capabilities that is `iss` by the relay.  `request_token/clerk`  should check if the signing ethereum address is in the clerks account array before creating the token. 

## Subscription Request
The Subscription Request has been changed to CBOR and is now signed and MUST include a capability with `aud` that matches the signing key of the request.

## Shop State: Accounts
Accounts has been renamed to ClerkAccounts which only contains an array of clerk accounts that is populated from onchain events. In the future this can be removed as well. 

## Future Work
- Add the ability to revoke, this needs to happen onchain
- The SIWE  message could be used directly for creating token. To do this we would need to define a how to encoded the token as a SIWE message.  
- delegation is not being used, but once we define SIWE <-> COSE mappings then the merchant would create a token for the clerks ethereum address instead of adding them onchain. The clerk would then create another token delegating the capabilities  to their keycard. 
- After delegation we can remove adding clerks onchain

closes https://github.com/masslbs/network-schema/issues/40